### PR TITLE
fix: React ^15.0.0 remove the method getDOMNode.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var React = require('react');
+var ReactDOM = require('react-dom');
 var qr = require('qr.js');
 
 function getBackingStorePixelRatio(ctx) {
@@ -21,7 +22,7 @@ if (/^0\.14/.test(React.version)) {
     }
 } else {
     getDOMNode = function(red) {
-        return ref.getDOMNode();
+        return ReactDOM.findDOMNode(ref);
     }
 }
 


### PR DESCRIPTION
[#5570](https://github.com/facebook/react/pull/5570)