### PR TITLE
Add props for setting logo size

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@ ReactDOM.render(
 
 ## Available Props
 
-prop      | type                 | default value
-----------|----------------------|-----------------------------------
-`value`   | `string`             | `http://facebook.github.io/react/`
-`size`    | `number`             | `128`
-`bgColor` | `string` (CSS color) | `"#FFFFFF"`
-`fgColor` | `string` (CSS color) | `"#000000"`
-`logo`    | `string` (URL / PATH)|
+prop         | type                 | default value
+-------------|----------------------|-----------------------------------
+`value`      | `string`             | `http://facebook.github.io/react/`
+`size`       | `number`             | `128`
+`bgColor`    | `string` (CSS color) | `"#FFFFFF"`
+`fgColor`    | `string` (CSS color) | `"#000000"`
+`logo`       | `string` (URL / PATH)|
+`logoWidth`  | `number`             | `size * 0.2`
+`logoHeight` | `number`             | Proportional scaling to `logoWidth`
 
 <img src="qrcode.png" height="256" width="256">

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,9 @@ var QRCode = React.createClass({
         size: React.PropTypes.number,
         bgColor: React.PropTypes.string,
         fgColor: React.PropTypes.string,
-        logo: React.PropTypes.string
+        logo: React.PropTypes.string,
+        logoWidth: React.PropTypes.number,
+        logoHeight: React.PropTypes.number
     },
 
     getDefaultProps: function() {
@@ -102,13 +104,14 @@ var QRCode = React.createClass({
         }, this);
 
         if (this.props.logo) {
+            var self = this
             var size = this.props.size;
             var image = document.createElement('img');
             image.src = this.props.logo;
             image.onload = function() {
-                var dwidth = size * 0.2;
+                var dwidth = self.props.logoWidth || size * 0.2;
+                var dheight = self.props.logoHeight || image.height / image.width * dwidth;
                 var dx = (size - dwidth) / 2;
-                var dheight = image.height / image.width * dwidth;
                 var dy = (size - dheight) / 2;
                 image.width = dwidth;
                 image.height = dheight;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/cssivision/qrcode-react#readme",
   "peerDependencies": {
-    "react": "0.12 - 0.15"
+    "react": "0.12 - 15.5"
   },
   "dependencies": {
     "qr.js": "0.0.0"


### PR DESCRIPTION
This PR enables the option for the users to specify the size of the logo themselves, for example by passing in `logoWidth` to set a specific width and automatically calculate the height, or `logoWidth` and `logoHeight` to set both values.