### PR TITLE
Use class extends React.Component and prop-types library

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var React = require('react');
+var PropTypes = require('prop-types');
 var ReactDOM = require('react-dom');
 var qr = require('qr.js');
 
@@ -26,42 +27,23 @@ if (/^0\.14/.test(React.version)) {
     }
 }
 
-var QRCode = React.createClass({
-    propTypes: {
-        value: React.PropTypes.string.isRequired,
-        size: React.PropTypes.number,
-        bgColor: React.PropTypes.string,
-        fgColor: React.PropTypes.string,
-        logo: React.PropTypes.string,
-        logoWidth: React.PropTypes.number,
-        logoHeight: React.PropTypes.number
-    },
-
-    getDefaultProps: function() {
-        return {
-            size: 128,
-            bgColor: '#FFFFFF',
-            fgColor: '#000000',
-            value: 'http://facebook.github.io/react/',
-        };
-    },
-
-    shouldComponentUpdate: function(nextProps) {
+class QRCode extends React.Component {
+    shouldComponentUpdate(nextProps) {
         var that = this;
         return Object.keys(QRCode.propTypes).some(function(k) {
             return that.props[k] !== nextProps[k];
         });
-    },
+    }
 
-    componentDidMount: function() {
+    componentDidMount() {
         this.update();
-    },
+    }
 
-    componentDidUpdate: function() {
+    componentDidUpdate() {
         this.update();
-    },
+    }
 
-    utf16to8: function(str) {
+    utf16to8(str) {
         var out, i, len, c;
         out = "";
         len = str.length;
@@ -79,9 +61,9 @@ var QRCode = React.createClass({
             }
         }
         return out;
-    },
+    }
 
-    update: function() {
+    update() {
         var value = this.utf16to8(this.props.value);
         var qrcode = qr(value);
         var canvas = getDOMNode(this.refs.canvas);
@@ -118,9 +100,9 @@ var QRCode = React.createClass({
                 ctx.drawImage(image, dx, dy, dwidth, dheight);
             }
         }
-    },
+    }
 
-    render: function() {
+    render() {
         return React.createElement('canvas', {
             style: { height: this.props.size, width: this.props.size },
             height: this.props.size,
@@ -128,6 +110,23 @@ var QRCode = React.createClass({
             ref: 'canvas'
         });
     }
-});
+}
+
+QRCode.propTypes = {
+    value: PropTypes.string.isRequired,
+    size: PropTypes.number,
+    bgColor: PropTypes.string,
+    fgColor: PropTypes.string,
+    logo: PropTypes.string,
+    logoWidth: PropTypes.number,
+    logoHeight: PropTypes.number
+};
+
+QRCode.defaultProps = {
+    size: 128,
+    bgColor: '#FFFFFF',
+    fgColor: '#000000',
+    value: 'http://facebook.github.io/react/'
+};
 
 module.exports = QRCode;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/cssivision/qrcode-react#readme",
   "peerDependencies": {
-    "react": "0.12 - 15.5"
+    "react": "0.12 - 15.6"
   },
   "dependencies": {
     "qr.js": "0.0.0"
@@ -31,6 +31,7 @@
   "devDependencies": {
     "babel-preset-react": "^6.1.18",
     "babelify": "^7.2.0",
+    "prop-types": "^15.5.10",
     "react": "^0.14.7",
     "react-dom": "^0.14.3"
   }


### PR DESCRIPTION
There are 2 main updates:

1- Change the way the class is created since createClass is being deprecated in v16. This way there is no need to use the create-react-class migration library.
2-Use the library prop-types because accessing propTypes directly from react will be also deprecated.