### PR TITLE
Pre-compile to ES5 for npm distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+dist/

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/cssivision/qrcode-react#readme",
   "peerDependencies": {
-    "react": "0.12 - 15.6"
+    "react": "0.12 - 16.2"
   },
   "dependencies": {
     "qr.js": "0.0.0"

--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "name": "qrcode-react",
   "version": "0.1.15",
   "description": "React component to generate QRCode with logo",
-  "main": "lib/index.js",
+  "main": "dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "browserify -t [ babelify --presets [ react ] ] example/index.js -o example/bundle.js"
+    "build": "babel lib/index.js --out-file dist/index.js --presets=es2015",
+    "build-example": "browserify -t [ babelify --presets [ react ] ] example/index.js -o example/bundle.js"
   },
   "repository": {
     "type": "git",
@@ -29,6 +30,8 @@
     "qr.js": "0.0.0"
   },
   "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.1.18",
     "babelify": "^7.2.0",
     "prop-types": "^15.5.10",


### PR DESCRIPTION
- Moves the build script for the example from `npm run build` to `npm run build-example`
- Adds `npm run build`, which uses babel to compile the module from ES6 down to ES5
- Adds `dist/` (the build output directory) to `.gitignore`

Keep in mind that for this to work you have to run `npm run build` before publishing to npm (or some tooling like [`np`](https://github.com/sindresorhus/np) will do it automatically for you).

---

Closes #16